### PR TITLE
add option to specify regex for the file matching.

### DIFF
--- a/bin/test.js
+++ b/bin/test.js
@@ -215,11 +215,12 @@ var is_directory = function is_directory(filename) {
 };
 
 var entry = _path2.default.resolve(process.argv[2]);
+var file_filter = process.argv[3] ? new RegExp(process.argv[3]) : /\.js$/;
+process.argv = process.argv.slice(1);
 
 if (is_directory(entry)) {
   var files = (0, _shelljs.find)(entry).filter(function (arg) {
-    return (/\.js$/.test(arg)
-    );
+    return file_filter.test(arg) || arg.indexOf('_hooks.js') > 0;
   }).sort();
   files.forEach(function (file) {
     _utils.log.info('Adding test file:', file);
@@ -229,3 +230,4 @@ if (is_directory(entry)) {
 } else {
   require(entry);
 }
+

--- a/src/test.js
+++ b/src/test.js
@@ -170,9 +170,11 @@ const is_directory = filename => {
 }
 
 let entry = path.resolve(process.argv[2]);
+let file_filter = process.argv[3]?new RegExp(process.argv[3]):/\.js$/
+process.argv = process.argv.slice(1);
 
 if (is_directory(entry)) {
-  let files = find(entry).filter(arg => /\.js$/.test(arg)).sort();
+  let files = find(entry).filter(arg => file_filter.test(arg) || arg.indexOf('_hooks.js') > 0).sort();
   files.forEach(file => {
     log.info('Adding test file:', file);
     __tests__.addFile(file);


### PR DESCRIPTION
Eric, let me know if this PR makes sense or you have a better idea. I want to keep test file next to the module in src and with this regex 3rd argument I can do it. I run the command as:

> ease-test     src     .test.js$

and it picks up all my <module>.test.js files and adds to the test file list.
